### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
+[![Board Status](https://dev.azure.com/xiaonaz/e25454f2-3801-40f0-9249-c6b22502c3b9/59f59e2d-17d8-4dd1-85a7-7177f1c33f6f/_apis/work/boardbadge/03cb989c-7131-4e57-aaa5-899dd9ea7678)](https://dev.azure.com/xiaonaz/e25454f2-3801-40f0-9249-c6b22502c3b9/_boards/board/t/59f59e2d-17d8-4dd1-85a7-7177f1c33f6f/Microsoft.RequirementCategory)
 # testproject
 Test project


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#2](https://dev.azure.com/xiaonaz/e25454f2-3801-40f0-9249-c6b22502c3b9/_workitems/edit/2). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.